### PR TITLE
startup server redirects to dashboard within same tab

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -110,8 +110,7 @@ def run_server(args):
         socketio.start_background_task(target=consumer.process_data_live)
         socketio.start_background_task(target=radio_producer.listen_to_radio)
 
-    print(f"Starting socketio server, \033[1;31mopen localhost:{SOCKETIO_PORT} in your browser\033[0m")
-    webbrowser.open(f'http://localhost:{SOCKETIO_PORT}')
+    print(f"Starting socketio server on localhost:{SOCKETIO_PORT}")
     socketio.run(socketio_app, debug=False, allow_unsafe_werkzeug=True, host="0.0.0.0", port=SOCKETIO_PORT)
 
 def main():

--- a/src/startup_server.py
+++ b/src/startup_server.py
@@ -168,7 +168,7 @@ def launch_startup_options(run_server_callback, socketio_port=5500):
         shutdown_func = request.environ.get("werkzeug.server.shutdown")
 
         # Launch the real server in a new thread
-        t = threading.Thread(target=lambda: run_server_callback(opts), daemon=True)
+        t = threading.Thread(target=lambda: run_server_callback(opts))
         t.start()
 
         # Close the setup server and redirect to the real app


### PR DESCRIPTION
Instead of opening a new tab for the main server, the startup options browser page will redirect to the main web server from within the same tab.